### PR TITLE
Support Arm and Arm64

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,12 +120,14 @@ Or this can be set to a [semver range](https://devhints.io/semver#ranges) (e.g. 
 
 ## Getting Started for developers
 
-Clone this github repository and bild the project with visual studio.
+Clone this github repository and bild the project with Visual Studio.
 
 Start the Launcher via the commandline:
-```sh
+```pwsh
 fiskaltrust.Launcher.exe run --cashbox-id <cashboxid> --access-token <accesstoken> --sandbox
 ```
+
+When using VS Code, please ensure that the following command line parameters are passed to `dotnet build` to enable seamless debugging: `-p:PublishSingleFile=true -p:PublishReadyToRun=true`.
 
 ## FAQ
 

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -25,6 +25,14 @@ stages:
           vmImage: ubuntu-latest
           target: linux-x64
 
+        linux-arm:
+          vmImage: ubuntu-latest
+          target: linux-arm
+
+        linux-arm64:
+          vmImage: ubuntu-latest
+          target: linux-arm64
+
         osx-x64:
           vmImage: macos-latest
           target: osx-x64

--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -46,7 +46,7 @@ stages:
     - ${{ each project in parameters.projects }}:
       - pwsh: |
           mv ./Directory.build.props ./Directory.Build.props
-          dotnet publish ./src/${{ project }}/${{ project }}.csproj -c ${{ parameters.config }} -o $(Build.ArtifactStagingDirectory)/drop-$(target) -r $(target) -f net6.0 --self-contained true /p:EnableCompressionInSingleFile=true /p:DebugType=None /p:DebugSymbols=false /p:GenerateRuntimeConfigurationFiles=false
+          dotnet publish ./src/${{ project }}/${{ project }}.csproj -c ${{ parameters.config }} -o $(Build.ArtifactStagingDirectory)/drop-$(target) -r $(target) -f net6.0 --self-contained true /p:EnableCompressionInSingleFile=true /p:DebugType=None /p:DebugSymbols=false /p:GenerateRuntimeConfigurationFiles=false -p:PublishSingleFile=true -p:PublishReadyToRun=true
         displayName: Publish
 
     - publish: $(Build.ArtifactStagingDirectory)/drop-$(target)

--- a/azure-pipelines/templates/stages/release.yml
+++ b/azure-pipelines/templates/stages/release.yml
@@ -12,6 +12,8 @@ parameters:
   - win-x64
   - win-x86
   - linux-x64
+  - linux-arm
+  - linux-arm64
   - osx-x64
 
 stages:

--- a/src/fiskaltrust.Launcher.Common/Configuration/Configuration.cs
+++ b/src/fiskaltrust.Launcher.Common/Configuration/Configuration.cs
@@ -3,10 +3,10 @@ using System.Text.Encodings.Web;
 using System.Text.Json;
 using System.Text.Json.Serialization;
 using fiskaltrust.Launcher.Common.Constants;
-using fiskaltrust.storage.encryption.V0;
 using fiskaltrust.Launcher.Common.Helpers.Serialization;
 using Microsoft.Extensions.Logging;
-using System.Text;
+using System.Security.Cryptography;
+using fiskaltrust.Launcher.Common.Helpers;
 
 namespace fiskaltrust.Launcher.Common.Configuration
 {
@@ -247,7 +247,9 @@ namespace fiskaltrust.Launcher.Common.Configuration
             MapFieldsWithAttribute<EncryptAttribute>(value =>
             {
                 if (value is null) { return null; }
-                return Convert.ToBase64String(Encryption.Encrypt(Encoding.UTF8.GetBytes((string)value), Convert.FromBase64String(accessTokenInner)));
+                using var aes = Aes.Create();
+
+                return Convert.ToBase64String(AesHelper.Encrypt((string)value, Convert.FromBase64String(accessTokenInner)));
             });
         }
 
@@ -263,7 +265,7 @@ namespace fiskaltrust.Launcher.Common.Configuration
             {
                 if (value is null) { return null; }
 
-                return Encoding.UTF8.GetString(Encryption.Decrypt(Convert.FromBase64String((string)value), Convert.FromBase64String(accessTokenInner)));
+                return AesHelper.Decrypt((string)value, Convert.FromBase64String(accessTokenInner));
             });
         }
     }

--- a/src/fiskaltrust.Launcher.Common/Helpers/AesHelper.cs
+++ b/src/fiskaltrust.Launcher.Common/Helpers/AesHelper.cs
@@ -1,0 +1,54 @@
+﻿using System.Security.Cryptography;
+
+namespace fiskaltrust.Launcher.Common.Helpers
+{
+    public static class AesHelper
+    {
+        public static byte[] Encrypt(string plainText, byte[] key)
+        {
+            if (plainText == null || plainText.Length <= 0)
+                throw new ArgumentNullException(nameof(plainText));
+            if (key == null || key.Length <= 0)
+                throw new ArgumentNullException(nameof(key));
+
+            using var aes = Aes.Create();
+            aes.Key = key.Take(16).ToArray();
+            aes.IV = Guid.NewGuid().ToByteArray();
+
+            var encryptor = aes.CreateEncryptor(aes.Key, aes.IV);
+
+            using var ms = new MemoryStream();
+            ms.Write(aes.IV);
+
+            using (var cs = new CryptoStream(ms, encryptor, CryptoStreamMode.Write))
+            using (var sw = new StreamWriter(cs))
+            {
+                sw.Write(plainText);
+            }
+            
+            return ms.ToArray();
+        }
+
+        public static string Decrypt(string secretBase64, byte[] key)
+        {
+            if (string.IsNullOrEmpty(secretBase64))
+                throw new ArgumentNullException(nameof(secretBase64));
+            if (key == null || key.Length <= 0)
+                throw new ArgumentNullException(nameof(key));
+
+            var secret = Convert.FromBase64String(secretBase64);
+
+            using var aes = Aes.Create();
+            aes.Key = key.Take(16).ToArray();
+            aes.IV = secret.Take(16).ToArray();
+
+            var decryptor = aes.CreateDecryptor(aes.Key, aes.IV);
+
+            using var ms = new MemoryStream(secret.Skip(16).ToArray());
+            using var cs = new CryptoStream(ms, decryptor, CryptoStreamMode.Read);
+            using var sr = new StreamReader(cs);
+
+            return sr.ReadToEnd();
+        }
+    }
+}

--- a/src/fiskaltrust.Launcher.Common/fiskaltrust.Launcher.Common.csproj
+++ b/src/fiskaltrust.Launcher.Common/fiskaltrust.Launcher.Common.csproj
@@ -11,8 +11,6 @@
     <PackageReference Include="Serilog.Sinks.Console" Version="4.1.0" />
     <PackageReference Include="Serilog.Sinks.File" Version="5.0.0" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
-    <PackageReference Include="fiskaltrust.storage.encryption" Version="1.3.1" />
-    <PackageReference Include="Portable.BouncyCastle" Version="1.9.0" />
   </ItemGroup>
 
 </Project>

--- a/src/fiskaltrust.Launcher/Commands/Common.cs
+++ b/src/fiskaltrust.Launcher/Commands/Common.cs
@@ -50,7 +50,7 @@ namespace fiskaltrust.Launcher.Commands
 
         public async Task<int> InvokeAsync(InvocationContext context)
         {
-            _clientEcdh = Encryption.CreateCurve();
+            _clientEcdh = CashboxConfigEncryption.CreateCurve();
 
             var collectionSink = new CollectionSink();
             Log.Logger = new LoggerConfiguration()

--- a/src/fiskaltrust.Launcher/Configuration/CashBoxConfigurationExt.cs
+++ b/src/fiskaltrust.Launcher/Configuration/CashBoxConfigurationExt.cs
@@ -14,7 +14,7 @@ namespace fiskaltrust.Launcher.Configuration
 
         public static void Decrypt(this ftCashBoxConfiguration cashboxConfiguration, LauncherConfiguration launcherConfiguration, ECDiffieHellman curve)
         {
-            var encryptionHelper = new Encryption(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, curve);
+            var encryptionHelper = new CashboxConfigEncryption(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, curve);
 
             foreach (var queue in cashboxConfiguration.ftQueues)
             {

--- a/src/fiskaltrust.Launcher/Configuration/LegacyConfigFileReader.cs
+++ b/src/fiskaltrust.Launcher/Configuration/LegacyConfigFileReader.cs
@@ -23,7 +23,15 @@ namespace fiskaltrust.Launcher.Configuration
                     var value = item.Attribute("value")?.Value;
                     if (key is not null && value is not null)
                     {
-                        SetProperies(launcherConfiguration, key!, value!);
+                        if (key == "proxy")
+                        {
+                            Log.Warning("Proxy settings can currently not be migrated from legacy config files. Please set the proxy with the '{executable} config set --proxy' command.",
+                                OperatingSystem.IsWindows() ? "fiskaltrust.Launcher.exe" : "./fiskaltrust.Launcher");
+                        }
+                        else
+                        {
+                            SetProperies(launcherConfiguration, key!, value!);
+                        }
                     }
                 }
             }
@@ -81,9 +89,10 @@ namespace fiskaltrust.Launcher.Configuration
             {
                 launcherConfiguration.DownloadRetry = int.Parse(value);
             }
-            else if (key == "proxy")
+            else
             {
-                launcherConfiguration.Proxy = value;
+                Log.Warning("The legacy configuration option '{key}' cannot be automatically parsed. Please use the '{executable} config set --help' argument to list compatible options.",
+                    key, OperatingSystem.IsWindows() ? "fiskaltrust.Launcher.exe" : "./fiskaltrust.Launcher");
             }
         }
     }

--- a/src/fiskaltrust.Launcher/Constants/Runtime.cs
+++ b/src/fiskaltrust.Launcher/Constants/Runtime.cs
@@ -1,3 +1,5 @@
+using System.Runtime.InteropServices;
+
 namespace fiskaltrust.Launcher.Constants
 {
     public class Runtime
@@ -6,24 +8,31 @@ namespace fiskaltrust.Launcher.Constants
         {
             get
             {
-                string runtimeIdentifier = Environment.Is64BitProcess ? "x64" : "x86";
-                if (OperatingSystem.IsWindows())
+                var arch = RuntimeInformation.OSArchitecture switch
                 {
-                    runtimeIdentifier = $"win-{runtimeIdentifier}";
+                    Architecture.X64 => "x64",
+                    Architecture.X86 => "x86",
+                    Architecture.Arm64 => "arm64",
+                    Architecture.Arm => "arm",
+                    _ => throw new NotImplementedException($"The processor architecture {RuntimeInformation.ProcessArchitecture} is currently not supported.")
+                };
+
+                if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+                {
+                    return $"win-{arch}";
                 }
-                else if (OperatingSystem.IsLinux())
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))
                 {
-                    runtimeIdentifier = $"linux-{runtimeIdentifier}";
+                    return $"linux-{arch}";
                 }
-                else if (OperatingSystem.IsMacOS())
+                else if (RuntimeInformation.IsOSPlatform(OSPlatform.OSX))
                 {
-                    runtimeIdentifier = $"osx-{runtimeIdentifier}";
+                    return $"osx-{arch}";
                 }
                 else
                 {
-                    runtimeIdentifier = System.Runtime.InteropServices.RuntimeInformation.RuntimeIdentifier;
+                    throw new Exception("The Operating System could not be detected.");
                 }
-                return runtimeIdentifier;
             }
         }
     }

--- a/src/fiskaltrust.Launcher/Download/ConfigurationDownloader.cs
+++ b/src/fiskaltrust.Launcher/Download/ConfigurationDownloader.cs
@@ -30,7 +30,7 @@ namespace fiskaltrust.Launcher.Download
                 return File.Exists(_configuration.CashboxConfigurationFile!);
             }
 
-            var clientPublicKey = Convert.ToBase64String(Encryption.CreateCurve().PublicKey.ExportSubjectPublicKeyInfo());
+            var clientPublicKey = Convert.ToBase64String(CashboxConfigEncryption.CreateCurve().PublicKey.ExportSubjectPublicKeyInfo());
 
             var request = new HttpRequestMessage(HttpMethod.Get, new Uri($"{_configuration.ConfigurationUrl}api/configuration/{_configuration.CashboxId}"));
             request.Headers.Add("accesstoken", _configuration.AccessToken);

--- a/src/fiskaltrust.Launcher/Extensions/LifetimeExtensions.cs
+++ b/src/fiskaltrust.Launcher/Extensions/LifetimeExtensions.cs
@@ -58,13 +58,12 @@ namespace fiskaltrust.Launcher.Extensions
 
         public void ServiceStartupCompleted()
         {
-            ApplicationLifetime.ApplicationStarted.Register(() => _started.SetResult());
-            _started.SetResult();
+            ApplicationLifetime.ApplicationStarted.Register(() => _started.TrySetResult());
         }
 
         public async Task WaitForStartAsync(CancellationToken cancellationToken)
         {
-            cancellationToken.Register(() => _started.SetResult());
+            cancellationToken.Register(() => _started.TrySetResult());
 
             await _started.Task;
         }

--- a/src/fiskaltrust.Launcher/Extensions/WebApplicationExtensions.cs
+++ b/src/fiskaltrust.Launcher/Extensions/WebApplicationExtensions.cs
@@ -38,8 +38,8 @@ namespace fiskaltrust.Launcher.Extensions
             app.MapMultiplePrefixed(_prefixes, "StartTransaction", EndpointRouteBuilderExtensions.MapPost, async (StartTransactionRequest req) => await sscd.StartTransactionAsync(req));
             app.MapMultiplePrefixed(_prefixes, "UpdateTransaction", EndpointRouteBuilderExtensions.MapPost, async (UpdateTransactionRequest req) => await sscd.UpdateTransactionAsync(req));
             app.MapMultiplePrefixed(_prefixes, "FinishTransaction", EndpointRouteBuilderExtensions.MapPost, async (FinishTransactionRequest req) => await sscd.FinishTransactionAsync(req));
-            app.MapMultiplePrefixed(_prefixes, "GetTseInfo", EndpointRouteBuilderExtensions.MapPost, async () => await sscd.GetTseInfoAsync());
-            app.MapMultiplePrefixed(_prefixes, "SetTseState", EndpointRouteBuilderExtensions.MapPost, async (TseState req) => await sscd.SetTseStateAsync(req));
+            app.MapMultiplePrefixed(_prefixes, "TseInfo", EndpointRouteBuilderExtensions.MapGet, async () => await sscd.GetTseInfoAsync());
+            app.MapMultiplePrefixed(_prefixes, "TseState", EndpointRouteBuilderExtensions.MapPost, async (TseState req) => await sscd.SetTseStateAsync(req));
             app.MapMultiplePrefixed(_prefixes, "RegisterClientId", EndpointRouteBuilderExtensions.MapPost, async (RegisterClientIdRequest req) => await sscd.RegisterClientIdAsync(req));
             app.MapMultiplePrefixed(_prefixes, "UnregisterClientId", EndpointRouteBuilderExtensions.MapPost, async (UnregisterClientIdRequest req) => await sscd.UnregisterClientIdAsync(req));
             app.MapMultiplePrefixed(_prefixes, "ExecuteSetTseTime", EndpointRouteBuilderExtensions.MapPost, async () => await sscd.ExecuteSetTseTimeAsync());

--- a/src/fiskaltrust.Launcher/Helpers/Encryption.cs
+++ b/src/fiskaltrust.Launcher/Helpers/Encryption.cs
@@ -3,19 +3,29 @@ using System.Text;
 
 namespace fiskaltrust.Launcher.Helpers
 {
-    public class Encryption
+    public class CashboxConfigEncryption
     {
         private readonly byte[] _clientSharedSecret;
         private readonly byte[] _iv;
         private readonly ECDiffieHellman _curve;
 
-        public Encryption(Guid cashboxId, string accessToken, ECDiffieHellman curve)
+        public CashboxConfigEncryption(Guid cashboxId, string accessToken, ECDiffieHellman curve)
         {
             _curve = curve;
             using var serverPublicKeyDh = ParsePublicKey(Convert.FromBase64String(accessToken));
             _clientSharedSecret = _curve.DeriveKeyMaterial(serverPublicKeyDh);
-
             _iv = cashboxId.ToByteArray();
+        }
+
+        public static ECDiffieHellman CreateCurve() => ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256);
+
+        public string Decrypt(string valueBase64)
+        {
+            var encrypted = Convert.FromBase64String(valueBase64);
+            using var aes = Aes.Create();
+            aes.Key = _clientSharedSecret;
+            var decrypted = aes.DecryptCbc(encrypted, _iv);
+            return Encoding.UTF8.GetString(decrypted);
         }
 
         private static ECDiffieHellmanPublicKey ParsePublicKey(byte[] publicKey)
@@ -36,17 +46,5 @@ namespace fiskaltrust.Launcher.Helpers
             using ECDiffieHellman dh = ECDiffieHellman.Create(parameters);
             return dh.PublicKey;
         }
-
-        public static ECDiffieHellman CreateCurve() => ECDiffieHellman.Create(ECCurve.NamedCurves.nistP256);
-
-        public string Decrypt(string valueBase64)
-        {
-            var encrypted = Convert.FromBase64String(valueBase64);
-            using var aes = Aes.Create();
-            aes.Key = _clientSharedSecret;
-            var decrypted = aes.DecryptCbc(encrypted, _iv);
-            return Encoding.UTF8.GetString(decrypted);
-        }
-
     }
 }

--- a/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
+++ b/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
@@ -25,7 +25,7 @@
     <PackageReference Include="protobuf-net.Grpc.AspNetCore" Version="1.0.179" />
     <PackageReference Include="System.CommandLine.Hosting" Version="0.3.0-alpha.21216.1" />
     <PackageReference Include="McMaster.NETCore.Plugins" Version="1.4.0" />
-	  <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
+	<PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="7.0.0" />
     <PackageReference Include="System.Linq.Async" Version="6.0.1" />
     <PackageReference Include="SemanticVersioning" Version="2.0.2" />
     <PackageReference Include="DiffPlex" Version="1.7.1" />

--- a/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
+++ b/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
@@ -4,9 +4,6 @@
     <OutputType>Exe</OutputType>
     <TargetFramework>net6.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
-    <PublishReadyToRun>true</PublishReadyToRun>
-    <PublishSingleFile>true</PublishSingleFile>
-    <!-- <PublishTrimmed>true</PublishTrimmed> -->
     <Nullable>enable</Nullable>
   </PropertyGroup>
 

--- a/test/fiskaltrust.Launcher.IntegrationTest/Download/PackageDownloaderTest.cs
+++ b/test/fiskaltrust.Launcher.IntegrationTest/Download/PackageDownloaderTest.cs
@@ -61,6 +61,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Download
                 "linux-x64",
                 "osx-x86",
                 "osx-x64",
+                // TODO: Add linux-arm and linux-arm64 after deployment went through
             };
 
             var targetPath = Path.Combine(launcherConfiguration.ServiceFolder!, "service", launcherConfiguration.CashboxId?.ToString()!, PackageDownloader.LAUNCHER_NAME);

--- a/test/fiskaltrust.Launcher.UnitTest/Helpers/AesHelperTests.cs
+++ b/test/fiskaltrust.Launcher.UnitTest/Helpers/AesHelperTests.cs
@@ -1,0 +1,22 @@
+﻿using fiskaltrust.Launcher.Common.Helpers;
+using FluentAssertions;
+
+namespace fiskaltrust.Launcher.UnitTest.Helpers
+{
+    public class AesHelperTests
+    {
+        [Fact]
+        public void EncryptDecrypt_Should_Return_OriginalValue()
+        {
+            var inputText = "Hello, World!";
+            var key = Convert.FromBase64String("BCYOqMDlzarfanZGTPu0AoIe7sKmCd8xARjYZqx7wf2V42bbul4wCEw51JUAWFQ5l7YLx6kuX7sLPwxaK6cEuq4=");
+
+            var encrypted = AesHelper.Encrypt(inputText, key);
+            encrypted.Should().NotBeNullOrEmpty();
+
+            var decrypted = AesHelper.Decrypt(Convert.ToBase64String(encrypted), key);
+            decrypted.Should().NotBeNullOrEmpty();
+            decrypted.Should().Be(inputText);
+        }
+    }
+}

--- a/test/fiskaltrust.Launcher.UnitTest/fiskaltrust.Launcher.UnitTest.csproj
+++ b/test/fiskaltrust.Launcher.UnitTest/fiskaltrust.Launcher.UnitTest.csproj
@@ -31,7 +31,7 @@
 
   <Target Name="CopyLauncherUpdater" AfterTargets="Build">
     <ItemGroup>
-      <LauncherUpdater Include="..\..\src\fiskaltrust.LauncherUpdater\bin\$(Configuration)\$(TargetFramework)\*"/>
+      <LauncherUpdater Include="..\..\src\fiskaltrust.LauncherUpdater\bin\$(Configuration)\$(TargetFramework)\*" />
     </ItemGroup>
     <Copy SourceFiles="@(LauncherUpdater)" DestinationFiles="$(OutputPath)/fiskaltrust.LauncherUpdater/%(Filename)%(Extension)" ContinueOnError="false" />
   </Target>


### PR DESCRIPTION
This PR adds support for _arm_ and arm64:

- [x] Add new build targets to the pipelines (arm and arm64)
- [x] Ensure that the correct libraries are loaded
- [x] Ensure that self-updates are still working

**Please note that _armel_ is currently not supported**.

Fixes #48.

Also replaces using the outdated encryption package that requires BouncyCastle with a .NET native implementation to fix the failing build.