### PR TITLE
Add TLS support

### DIFF
--- a/src/fiskaltrust.Launcher.Common/Configuration/Configuration.cs
+++ b/src/fiskaltrust.Launcher.Common/Configuration/Configuration.cs
@@ -119,12 +119,24 @@ namespace fiskaltrust.Launcher.Common.Configuration
 
         private bool? _sslValidation;
         [JsonPropertyName("sslValidation")]
-        public bool? SslValidation { get => WithDefault<bool?>(_sslValidation.GetValueOrDefault(false) ? true : null, true); set => _sslValidation = value; } // TODO implement
-
+        public bool? SslValidation { get =>_sslValidation.GetValueOrDefault(true); set => _sslValidation = value; }
+        
         [Encrypt]
         private string? _proxy = null;
         [JsonPropertyName("proxy")]
         public string? Proxy { get => _proxy; set => _proxy = value; }
+
+        private string? _tlsCertificatePath;
+        [JsonPropertyName("tlsCertificatePath")]
+        public string? TlsCertificatePath { get => _tlsCertificatePath; set => _tlsCertificatePath = value; }
+
+        private string? _tlsCertificateBase64;
+        [JsonPropertyName("tlsCertificateBase64")]
+        public string? TlsCertificateBase64 { get => _tlsCertificateBase64; set => _tlsCertificateBase64 = value; }
+        
+        private string? _tlsCertificatePassword;
+        [JsonPropertyName("tlsCertificatePassword")]
+        public string? TlsCertificatePassword { get => _tlsCertificatePassword; set => _tlsCertificatePassword = value; }
 
         private int? _processHostPingPeriodSec;
         [JsonPropertyName("processHostPingPeriodSec")]

--- a/src/fiskaltrust.Launcher/Clients/DESSCDClientFactory.cs
+++ b/src/fiskaltrust.Launcher/Clients/DESSCDClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using fiskaltrust.ifPOS.v1.de;
+using fiskaltrust.Launcher.Common.Configuration;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Interface.Client;
 using fiskaltrust.Middleware.Interface.Client.Grpc;
@@ -11,6 +12,10 @@ namespace fiskaltrust.Launcher.Clients
 {
     public class DESSCDClientFactory : IClientFactory<IDESSCD>
     {
+        private readonly LauncherConfiguration _launcherConfiguration;
+
+        public DESSCDClientFactory(LauncherConfiguration launcherConfiguration) => _launcherConfiguration = launcherConfiguration;
+
         public IDESSCD CreateClient(ClientConfiguration configuration)
         {
             if (configuration is null)
@@ -25,10 +30,12 @@ namespace fiskaltrust.Launcher.Clients
                 ClientTimeout = configuration.Timeout != default ? configuration.Timeout : RetryPolicyOptions.Default.ClientTimeout
             };
 
+            var isHttps = !string.IsNullOrEmpty(_launcherConfiguration?.TlsCertificatePath) || !string.IsNullOrEmpty(_launcherConfiguration?.TlsCertificateBase64);
+
             return configuration.UrlType switch
             {
                 "grpc" => GrpcDESSCDFactory.CreateSSCDAsync(new GrpcClientOptions { Url = new Uri(configuration.Url.Replace("grpc://", "http://")), RetryPolicyOptions = retryPolicyoptions, ChannelOptions = new GrpcChannelOptions { Credentials = ChannelCredentials.Insecure } }).Result,
-                "rest" => HttpDESSCDFactory.CreateSSCDAsync(new ClientOptions { Url = new Uri(configuration.Url.Replace("rest://", "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
+                "rest" => HttpDESSCDFactory.CreateSSCDAsync(new HttpDESSCDClientOptions { Url = new Uri(configuration.Url.Replace("rest://", isHttps ? "https://" : "http://")), RetryPolicyOptions = retryPolicyoptions, DisableSslValidation = _launcherConfiguration?.SslValidation }).Result,
                 "http" or "https" or "net.tcp" => SoapDESSCDFactory.CreateSSCDAsync(new ClientOptions { Url = new Uri(configuration.Url), RetryPolicyOptions = retryPolicyoptions }).Result,
                 _ => throw new ArgumentException("This version of the fiskaltrust Launcher currently only supports gRPC, REST and SOAP communication."),
             };

--- a/src/fiskaltrust.Launcher/Clients/POSClientFactory.cs
+++ b/src/fiskaltrust.Launcher/Clients/POSClientFactory.cs
@@ -1,4 +1,5 @@
 ﻿using fiskaltrust.ifPOS.v1;
+using fiskaltrust.Launcher.Common.Configuration;
 using fiskaltrust.Middleware.Abstractions;
 using fiskaltrust.Middleware.Interface.Client;
 using fiskaltrust.Middleware.Interface.Client.Grpc;
@@ -9,6 +10,10 @@ namespace fiskaltrust.Launcher.Clients
 {
     public class POSClientFactory : IClientFactory<IPOS>
     {
+        private readonly LauncherConfiguration _launcherConfiguration;
+
+        public POSClientFactory(LauncherConfiguration launcherConfiguration) => _launcherConfiguration = launcherConfiguration;
+
         public IPOS CreateClient(ClientConfiguration configuration)
         {
             if (configuration is null)
@@ -23,10 +28,12 @@ namespace fiskaltrust.Launcher.Clients
                 ClientTimeout = configuration.Timeout != default ? configuration.Timeout : RetryPolicyOptions.Default.ClientTimeout
             };
 
+            var isHttps = !string.IsNullOrEmpty(_launcherConfiguration.TlsCertificatePath) || !string.IsNullOrEmpty(_launcherConfiguration.TlsCertificateBase64);
+
             return configuration.UrlType switch
             {
                 "grpc" => GrpcPosFactory.CreatePosAsync(new GrpcClientOptions { Url = new Uri(configuration.Url.Replace("grpc://", "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
-                "rest" => HttpPosFactory.CreatePosAsync(new HttpPosClientOptions { Url = new Uri(configuration.Url.Replace("rest://", "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
+                "rest" => HttpPosFactory.CreatePosAsync(new HttpPosClientOptions { Url = new Uri(configuration.Url.Replace("rest://", isHttps ? "https://" : "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
                 "http" or "https" or "net.tcp" => SoapPosFactory.CreatePosAsync(new ClientOptions { Url = new Uri(configuration.Url), RetryPolicyOptions = retryPolicyoptions }).Result,
                 _ => throw new ArgumentException("This version of the fiskaltrust Launcher currently only supports gRPC, REST and SOAP communication."),
             };

--- a/src/fiskaltrust.Launcher/Clients/POSClientFactory.cs
+++ b/src/fiskaltrust.Launcher/Clients/POSClientFactory.cs
@@ -5,6 +5,8 @@ using fiskaltrust.Middleware.Interface.Client;
 using fiskaltrust.Middleware.Interface.Client.Grpc;
 using fiskaltrust.Middleware.Interface.Client.Http;
 using fiskaltrust.Middleware.Interface.Client.Soap;
+using Grpc.Core;
+using Grpc.Net.Client;
 
 namespace fiskaltrust.Launcher.Clients
 {
@@ -29,12 +31,31 @@ namespace fiskaltrust.Launcher.Clients
             };
 
             var isHttps = !string.IsNullOrEmpty(_launcherConfiguration.TlsCertificatePath) || !string.IsNullOrEmpty(_launcherConfiguration.TlsCertificateBase64);
+            var sslValidationDisabled = _launcherConfiguration != null && _launcherConfiguration.SslValidation.HasValue && _launcherConfiguration.SslValidation.Value;
 
             return configuration.UrlType switch
             {
-                "grpc" => GrpcPosFactory.CreatePosAsync(new GrpcClientOptions { Url = new Uri(configuration.Url.Replace("grpc://", "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
-                "rest" => HttpPosFactory.CreatePosAsync(new HttpPosClientOptions { Url = new Uri(configuration.Url.Replace("rest://", isHttps ? "https://" : "http://")), RetryPolicyOptions = retryPolicyoptions }).Result,
-                "http" or "https" or "net.tcp" => SoapPosFactory.CreatePosAsync(new ClientOptions { Url = new Uri(configuration.Url), RetryPolicyOptions = retryPolicyoptions }).Result,
+                "grpc" => GrpcPosFactory.CreatePosAsync(new GrpcClientOptions
+                {
+                    Url = new Uri(configuration.Url.Replace("grpc://", isHttps ? "https://" : "http://")),
+                    RetryPolicyOptions = retryPolicyoptions,
+                    ChannelOptions = new GrpcChannelOptions
+                    {
+                        Credentials = isHttps ? ChannelCredentials.SecureSsl : ChannelCredentials.Insecure,
+                        HttpHandler = isHttps && sslValidationDisabled ? new HttpClientHandler { ServerCertificateCustomValidationCallback = (httpRequestMessage, cert, cetChain, policyErrors) => true } : null
+                    }
+                }).Result,
+                "rest" => HttpPosFactory.CreatePosAsync(new HttpPosClientOptions
+                {
+                    Url = new Uri(configuration.Url.Replace("rest://", isHttps ? "https://" : "http://")),
+                    RetryPolicyOptions = retryPolicyoptions,
+                    DisableSslValidation = _launcherConfiguration?.SslValidation
+                }).Result,
+                "http" or "https" or "net.tcp" => SoapPosFactory.CreatePosAsync(new ClientOptions
+                {
+                    Url = new Uri(configuration.Url),
+                    RetryPolicyOptions = retryPolicyoptions
+                }).Result,
                 _ => throw new ArgumentException("This version of the fiskaltrust Launcher currently only supports gRPC, REST and SOAP communication."),
             };
         }

--- a/src/fiskaltrust.Launcher/Commands/HostCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/HostCommand.cs
@@ -75,7 +75,6 @@ namespace fiskaltrust.Launcher.Commands
 
             packageConfiguration.Configuration = packageConfiguration.Configuration.Union(DefaultPackageConfig(launcherConfiguration, cashboxConfiguration)).ToDictionary(k => k.Key, v => v.Value);
 
-
             IProcessHostService? processHostService = null;
             if (!NoProcessHostService)
             {

--- a/src/fiskaltrust.Launcher/Commands/RunCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/RunCommand.cs
@@ -26,6 +26,9 @@ namespace fiskaltrust.Launcher.Commands
             AddOption(new Option<string?>("--proxy"));
             AddOption(new Option<string?>("--processhost-ping-period-sec"));
             AddOption(new Option<string?>("--cashbox-configuration-file"));
+            AddOption(new Option<string?>("--tls-certificate-path"));
+            AddOption(new Option<string?>("--tls-certificate-base64"));
+            AddOption(new Option<string?>("--tls-certificate-password"));
         }
     }
 

--- a/src/fiskaltrust.Launcher/Services/HostingService.cs
+++ b/src/fiskaltrust.Launcher/Services/HostingService.cs
@@ -133,7 +133,7 @@ namespace fiskaltrust.Launcher.Services
         {
             builder.WebHost.ConfigureKestrel(options =>
             {
-                ConfigureKestrel(options, uri, _ => { });
+                ConfigureKestrel(options, uri, listenOptions => ConfigureTls(listenOptions));
                 options.AllowSynchronousIO = true;
             });
 

--- a/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
+++ b/src/fiskaltrust.Launcher/fiskaltrust.Launcher.csproj
@@ -15,7 +15,7 @@
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Soap" Version="1.3.42-ci-22319-57723" />
     <PackageReference Include="fiskaltrust.storage.serialization" Version="2.0.0-alpha1-22020-50210" />
     <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Grpc" Version="1.3.42-ci-22319-57723" />
-    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.40" />
+    <PackageReference Include="fiskaltrust.Middleware.Interface.Client.Http" Version="1.3.43-ci-22347-58405" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.0.1" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="5.0.1" />
     <PackageReference Include="Serilog.Formatting.Compact.Reader" Version="2.0.0" />

--- a/test/fiskaltrust.Launcher.IntegrationTest/Plebian/PlebianTests.cs
+++ b/test/fiskaltrust.Launcher.IntegrationTest/Plebian/PlebianTests.cs
@@ -32,7 +32,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
             await RunTest<IDESSCD>(new DummyDeSscd(), PackageType.SCU, packageConfiguration, async () =>
             {
-                var grpcClient = new DESSCDClientFactory().CreateClient(new ClientConfiguration
+                var grpcClient = new DESSCDClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[0],
                     UrlType = "grpc",
@@ -41,7 +41,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
                 (await grpcClient.EchoAsync(new ScuDeEchoRequest { Message = "test" })).Should().Match<ScuDeEchoResponse>(r => r.Message == "test");
 
-                var restClient = new DESSCDClientFactory().CreateClient(new ClientConfiguration
+                var restClient = new DESSCDClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[1],
                     UrlType = "rest",
@@ -51,7 +51,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
                 (await restClient.EchoAsync(new ScuDeEchoRequest { Message = "test" })).Should().NotBeNull().And.Match<ScuDeEchoResponse>(r => r.Message == "test");
 
-                var soapClientHttp = new DESSCDClientFactory().CreateClient(new ClientConfiguration
+                var soapClientHttp = new DESSCDClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[2],
                     UrlType = "http",
@@ -78,7 +78,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
             await RunTest<IPOS>(new DummyPos(), PackageType.Queue, packageConfiguration, async () =>
             {
-                var grpcClient = new POSClientFactory().CreateClient(new ClientConfiguration
+                var grpcClient = new POSClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[0],
                     UrlType = "grpc",
@@ -87,7 +87,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
                 (await grpcClient.EchoAsync(new EchoRequest { Message = "test" })).Should().Match<EchoResponse>(r => r.Message == "test");
 
-                var restClient = new POSClientFactory().CreateClient(new ClientConfiguration
+                var restClient = new POSClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[1],
                     UrlType = "rest",
@@ -96,7 +96,7 @@ namespace fiskaltrust.Launcher.IntegrationTest.Plebian
 
                 (await restClient.EchoAsync(new EchoRequest { Message = "test" })).Should().Match<EchoResponse>(r => r.Message == "test");
 
-                var soapClientHttp = new POSClientFactory().CreateClient(new ClientConfiguration
+                var soapClientHttp = new POSClientFactory(new LauncherConfiguration()).CreateClient(new ClientConfiguration
                 {
                     Url = packageConfiguration.Url[2],
                     UrlType = "http",


### PR DESCRIPTION
This PR adds TLS support to REST, gRPC and (if possible) SOAP.

- [x] REST
- [x] gRPC
- [x] SOAP

Fixes #7 