### PR TITLE
Store client ECDH in cashbox-specific path

### DIFF
--- a/src/fiskaltrust.Launcher/Commands/Common.cs
+++ b/src/fiskaltrust.Launcher/Commands/Common.cs
@@ -149,7 +149,7 @@ namespace fiskaltrust.Launcher.Commands
                 Log.Error(e, "Could not create cashbox-configuration-file folder.");
             }
 
-            var clientEcdh = await LoadCurve(launcherConfiguration.AccessToken!, launcherConfiguration.UseOffline!.Value);
+            var clientEcdh = await LoadCurve(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, launcherConfiguration.ServiceFolder!, launcherConfiguration.UseOffline!.Value);
 
             try
             {
@@ -228,11 +228,12 @@ namespace fiskaltrust.Launcher.Commands
             return await handler(options, new CommonProperties(launcherConfiguration, cashboxConfiguration, clientEcdh, dataProtectionProvider), specificOptions, host.Services.GetRequiredService<S>());
         }
 
-        public static async Task<ECDiffieHellman> LoadCurve(string accessToken, bool useOffline = false, bool dryRun = false, bool useFallback = false)
+        public static async Task<ECDiffieHellman> LoadCurve(Guid cashboxId, string accessToken, string serviceFolder, bool useOffline = false, bool dryRun = false, bool useFallback = false)
         {
             Log.Verbose("Loading Curve.");
             var dataProtector = DataProtectionExtensions.Create(accessToken, useFallback: useFallback).CreateProtector(CashBoxConfigurationExt.DATA_PROTECTION_DATA_PURPOSE);
-            var clientEcdhPath = Path.Combine(Common.Constants.Paths.CommonFolder, "fiskaltrust.Launcher", "client.ecdh");
+            var clientEcdhPath = Path.Combine(serviceFolder, $"client-{cashboxId}.ecdh");
+
             if (File.Exists(clientEcdhPath))
             {
                 return ECDiffieHellmanExt.Deserialize(dataProtector.Unprotect(await File.ReadAllTextAsync(clientEcdhPath)));

--- a/src/fiskaltrust.Launcher/Commands/Common.cs
+++ b/src/fiskaltrust.Launcher/Commands/Common.cs
@@ -1,6 +1,7 @@
 using System.CommandLine;
 using System.CommandLine.Invocation;
 using System.Security.Cryptography;
+using System.Text.Json;
 using fiskaltrust.Launcher.Common.Configuration;
 using fiskaltrust.Launcher.Common.Constants;
 using fiskaltrust.Launcher.Common.Extensions;
@@ -149,10 +150,10 @@ namespace fiskaltrust.Launcher.Commands
                 Log.Error(e, "Could not create cashbox-configuration-file folder.");
             }
 
-            var clientEcdh = await LoadCurve(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, launcherConfiguration.ServiceFolder!, launcherConfiguration.UseOffline!.Value);
-
+            ECDiffieHellman? clientEcdh = null;
             try
             {
+                clientEcdh = await LoadCurve(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, launcherConfiguration.ServiceFolder!, launcherConfiguration.UseOffline!.Value);
                 using var downloader = new ConfigurationDownloader(launcherConfiguration);
                 var exists = await downloader.DownloadConfigurationAsync(clientEcdh);
                 if (launcherConfiguration.UseOffline!.Value && !exists)

--- a/src/fiskaltrust.Launcher/Commands/DoctorCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/DoctorCommand.cs
@@ -86,7 +86,7 @@ namespace fiskaltrust.Launcher.Commands
 
                 launcherConfiguration.OverwriteWith(doctorOptions.ArgsLauncherConfiguration);
 
-                var clientEcdh = await checkUp.CheckAwait("Load ECDH Curve", async () => await CommonHandler.LoadCurve(launcherConfiguration.AccessToken!, launcherConfiguration.UseOffline!.Value, dryRun: true, useFallback: launcherConfiguration.UseLegacyDataProtection!.Value), critical: false);
+                var clientEcdh = await checkUp.CheckAwait("Load ECDH Curve", async () => await CommonHandler.LoadCurve(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, launcherConfiguration.ServiceFolder!, launcherConfiguration.UseOffline!.Value, dryRun: true, useFallback: launcherConfiguration.UseLegacyDataProtection!.Value), critical: false);
                 ftCashBoxConfiguration cashboxConfiguration = new();
 
                 if (clientEcdh is null)

--- a/src/fiskaltrust.Launcher/Commands/HostCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/HostCommand.cs
@@ -81,7 +81,7 @@ namespace fiskaltrust.Launcher.Commands
 
             var cashboxConfiguration = CashBoxConfigurationExt.Deserialize(await File.ReadAllTextAsync(launcherConfiguration.CashboxConfigurationFile!));
 
-            cashboxConfiguration.Decrypt(launcherConfiguration, await CommonHandler.LoadCurve(launcherConfiguration.AccessToken!, launcherConfiguration.UseLegacyDataProtection!.Value));
+            cashboxConfiguration.Decrypt(launcherConfiguration, await CommonHandler.LoadCurve(launcherConfiguration.CashboxId!.Value, launcherConfiguration.AccessToken!, launcherConfiguration.ServiceFolder!, launcherConfiguration.UseLegacyDataProtection!.Value));
 
             var packageConfiguration = (plebeianConfiguration.PackageType switch
             {


### PR DESCRIPTION
Currently, there are two issues when handling client curves we use for decrypting secrets:
1. They are stored in the "common" folder, which cannot be configured by the user. Instead, we should store it in the service folder.
2. The file is stored with a generic path (`client.ecdh`), which can lead to errors when multiple CashBoxes are ran on the same machine.
