### PR TITLE
Reduce memory usage of self-contained build

### DIFF
--- a/azure-pipelines/templates/stages/build.yml
+++ b/azure-pipelines/templates/stages/build.yml
@@ -50,7 +50,7 @@ stages:
           - ${{ each project in parameters.projects }}:
               - pwsh: |
                   mv ./Directory.build.props ./Directory.Build.props
-                  dotnet publish ./src/${{ project }}/${{ project }}.csproj -c ${{ parameters.config }} -o $(Build.ArtifactStagingDirectory)/drop-$(target) -r $(target) -f net8.0 --self-contained true /p:EnableCompressionInSingleFile=true /p:DebugType=None /p:DebugSymbols=false /p:GenerateRuntimeConfigurationFiles=false -p:PublishSingleFile=true -p:PublishReadyToRun=true
+                  dotnet publish ./src/${{ project }}/${{ project }}.csproj -c ${{ parameters.config }} -o $(Build.ArtifactStagingDirectory)/drop-$(target) -r $(target) -f net8.0 --self-contained true -p:DebugType=None -p:DebugSymbols=false -p:GenerateRuntimeConfigurationFiles=false -p:PublishSingleFile=true
                 displayName: "[${{ project }}] Publish"
 
           - task: codesigning@2

--- a/version.json
+++ b/version.json
@@ -1,5 +1,5 @@
 {
-  "version": "2.0.0-rc.15",
+  "version": "2.0.0-rc.16",
   "releaseBranches": [
     "^refs/tags/v\\d+(?:\\.\\d+)*(?:-.*)?$"
   ]


### PR DESCRIPTION
We had set the build settings `PublishReadyToRun` to speed up startup times and `EnableCompressionInSingleFile` to reduce binary size.

These settings lead to a memory consumption of ~150mb per launcher process.
With removing these settings we get a more acceptable memory consumption of ~25mb per launcher process.

The binary size increases by 50mb but this is a compromise we should take 😁