### PR TITLE
Read legacy configs from mono config files on Linux

### DIFF
--- a/src/fiskaltrust.Launcher.Common/Constants/Paths.cs
+++ b/src/fiskaltrust.Launcher.Common/Constants/Paths.cs
@@ -14,7 +14,17 @@ namespace fiskaltrust.Launcher.Common.Constants
 
         public static string LegacyConfigurationFileName
         {
-            get => "fiskaltrust.exe.config";
+            get
+            {
+                if (OperatingSystem.IsWindows())
+                {
+                    return "fiskaltrust.exe.config";
+                }
+                else
+                {
+                    return "fiskaltrust.mono.exe.config";
+                }
+            }
         }
 
         public static string CommonFolder


### PR DESCRIPTION
This PR adds support for reading the legacy config file `fiskaltrust.mono.exe.config` on Linux systems.