### PR TITLE
Improvements for systemd and legacy config migration

### DIFF
--- a/src/fiskaltrust.Launcher/Commands/Common.cs
+++ b/src/fiskaltrust.Launcher/Commands/Common.cs
@@ -124,7 +124,8 @@ namespace fiskaltrust.Launcher.Commands
             }
 
             Log.Verbose("Merging legacy launcher config file.");
-            if (options.MergeLegacyConfigIfExists && File.Exists(options.LegacyConfigurationFile))
+            var legacyFileBackupPath = options.LegacyConfigurationFile + ".legacy";
+            if (options.MergeLegacyConfigIfExists && File.Exists(options.LegacyConfigurationFile) && !File.Exists(legacyFileBackupPath))
             {
                 var legacyConfig = await LegacyConfigFileReader.ReadLegacyConfigFile(options.LegacyConfigurationFile);
                 launcherConfiguration.OverwriteWith(legacyConfig);
@@ -138,8 +139,7 @@ namespace fiskaltrust.Launcher.Commands
                 await File.WriteAllTextAsync(options.LauncherConfigurationFile, legacyConfig.Serialize());
 
                 var fi = new FileInfo(options.LegacyConfigurationFile);
-                fi.CopyTo(options.LegacyConfigurationFile + ".legacy");
-                fi.Delete();
+                fi.CopyTo(legacyFileBackupPath);
             }
 
             Log.Verbose("Merging launcher cli args.");

--- a/src/fiskaltrust.Launcher/Commands/InstallCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/InstallCommand.cs
@@ -1,5 +1,4 @@
 using System.CommandLine;
-using System.CommandLine.Invocation;
 using Serilog;
 using fiskaltrust.Launcher.ServiceInstallation;
 using fiskaltrust.Launcher.Helpers;
@@ -62,7 +61,8 @@ namespace fiskaltrust.Launcher.Commands
 
             if (OperatingSystem.IsLinux())
             {
-                installer = new LinuxSystemD(installOptions.ServiceName ?? $"fiskaltrust-{commonProperties.LauncherConfiguration.CashboxId}", installServices.LauncherExecutablePath);
+                installer = new LinuxSystemD(installOptions.ServiceName ?? $"fiskaltrust-{commonProperties.LauncherConfiguration.CashboxId}", 
+                    installServices.LauncherExecutablePath, commonProperties.LauncherConfiguration.ServiceFolder);
             }
             if (OperatingSystem.IsWindows())
             {

--- a/src/fiskaltrust.Launcher/Commands/UninstallCommand.cs
+++ b/src/fiskaltrust.Launcher/Commands/UninstallCommand.cs
@@ -41,7 +41,8 @@ namespace fiskaltrust.Launcher.Commands
             ServiceInstaller? installer = null;
             if (OperatingSystem.IsLinux())
             {
-                installer = new LinuxSystemD(uninstallOptions.ServiceName ?? $"fiskaltrust-{commonProperties.LauncherConfiguration.CashboxId}", uninstallServices.LauncherExecutablePath);
+                installer = new LinuxSystemD(uninstallOptions.ServiceName ?? $"fiskaltrust-{commonProperties.LauncherConfiguration.CashboxId}", 
+                    uninstallServices.LauncherExecutablePath, commonProperties.LauncherConfiguration.ServiceFolder);
             }
             if (OperatingSystem.IsWindows())
             {


### PR DESCRIPTION
This PR introduces two improvements for beta users in Austria that use the Launcher 2.0 on arm64 Linux:
- We now wait for dependencies when starting the Launcher as a systemd daemon (for the used directories to be mounted, and the network stack being alive)
- We now keep the original `fiskaltrust.exe.config`/`fiskaltrust.mono.exe.config` when migrating it to the new `launcher.configuration.json` format, since some POS syetems rely on those files to e.g. extract the cashbox ID.